### PR TITLE
changed the #endif placement in the comalive function

### DIFF
--- a/LinuxCNC_ArduinoConnector.ino
+++ b/LinuxCNC_ArduinoConnector.ino
@@ -635,10 +635,8 @@ void comalive(){
         else{
           digitalWrite(StatLedPin, HIGH);
         }
-          
+      #endif 
     }
-    
-  #endif
 }
 
 


### PR DESCRIPTION
Hello,

i have noticed if the STATUSLED is not defined you get a compiler error because of the wrong placement of the #endif statement in the comalive function. This leads to a not "compiled" } which results in wired compiler errors.