### PR TITLE
Added temperature sensor option

### DIFF
--- a/LinuxCNC_ArduinoConnector.ino
+++ b/LinuxCNC_ArduinoConnector.ino
@@ -19,6 +19,7 @@
   - Multiplexed LEDs
   - Quadrature encoders
   - Joysticks
+  - Dallas-compatible Temperature Sensors
   
   The Send and receive Protocol is <Signal><PinNumber>:<Pin State>
   To begin Transmitting Ready is send out and expects to receive E: to establish connection. Afterwards Data is exchanged.
@@ -34,6 +35,7 @@
   rotary encoder          = 'R' -write only  -Pin State: up/ down / -2147483648 to 2147483647
   joystick                = 'R' -write only  -Pin State: up/ down / -2147483648 to 2147483647
   multiplexed LEDs        = 'M' -read only   -Pin State: 0,1
+  temperature reading     = 'T' -read only   -Current Reading in C or F
 
 Keyboard Input:
   Matrix Keypad           = 'M' -write only  -Pin State: 0,1
@@ -98,6 +100,24 @@ Communication Status      = 'E' -read/Write  -Pin State: 0:0
   int AInPinmap[] = {0};                //Potentiometer for SpindleSpeed override
   int smooth = 200;                     //number of samples to denoise ADC, try lower numbers on your setup 200 worked good for me.
 #endif
+
+//#define DALLAS_TEMP_SENSOR
+#ifdef DALLAS_TEMP_SENSOR
+// Required Libaries: DallasTemperature, OneWire
+// In the US, Dallas-Compatible temp sensors can be found on Amazon at: https://www.amazon.com/gp/product/B08V93CTM2/ref=ppx_yo_dt_b_search_asin_title?ie=UTF8&psc=1
+// The current listing is titled: Gikfun DS18B20 Waterproof Digital Temperature Sensor with Adapter Module for Arduino (Pack of 3 Sets) EK1183
+// The nice thing about this sensor option is the provided pull-up circuitry and filter PCB (I believe its a filter cap, but I could be wrong)
+  #include <OneWire.h>
+  #include <DallasTemperature.h>
+
+  const int TmpSensors = 1;  // The Dallas-compatible sesnsors can share a pin and be indexed by an int value when reading.
+  // This version is expecting 1 sensor per pin. Future todo: add multi sensors per-pin support
+  int TmpSensorMap[] = {2};
+  DallasTemperature * TmpSensorControlMap[TmpSensors];
+  #define TEMP_OUTPUT_C 1 // 1 to output in C, any other value to output in F
+#endif
+
+
 
 
                        
@@ -328,6 +348,10 @@ const int debounceDelay = 50;
   int OutState[Outputs];
   int oldOutState[Outputs];
 #endif
+#ifdef DALLAS_TEMP_SENSOR
+  double inTmpSensorState[TmpSensors];
+  //int oldInTempSensorState[TmpSensors];
+#endif
 #ifdef PWMOUTPUTS
   int OutPWMState[PwmOutputs];
   int oldOutPWMState[PwmOutputs];
@@ -435,6 +459,21 @@ void setup() {
     oldOutPWMState[o] = 0;
     }
 #endif
+
+#ifdef DALLAS_TEMP_SENSOR
+
+  for(int o= 0; o<TmpSensors;o++){
+    pinMode(TmpSensorMap[o], OUTPUT);
+    inTmpSensorState[o] = -1;
+    // Setup a oneWire instance to communicate with any OneWire devices
+    OneWire * oneWire = new OneWire(TmpSensorMap[o]);
+
+    // Pass our oneWire reference to Dallas Temperature sensor 
+    DallasTemperature * sensors = new DallasTemperature(oneWire);
+    TmpSensorControlMap[o] = sensors;
+    }
+#endif
+
 #ifdef STATUSLED
   pinMode(StatLedPin, OUTPUT);
 #endif
@@ -475,6 +514,9 @@ void loop() {
 
 #ifdef INPUTS
   readInputs(); //read Inputs & send data
+#endif
+#ifdef DALLAS_TEMP_SENSOR
+  readTmpInputs();
 #endif
 #ifdef SINPUTS
   readsInputs(); //read Inputs & send data
@@ -677,6 +719,11 @@ void reconnect(){
   #ifdef INPUTS
     readInputs(); //read Inputs & send data
   #endif
+  
+  #ifdef DALLAS_TEMP_SENSOR
+    readTmpInputs(); //read Inputs & send data
+  #endif
+
   #ifdef SINPUTS
     readsInputs(); //read Inputs & send data
   #endif
@@ -832,6 +879,27 @@ void readInputs(){
         sendData('I',InPinmap[i],InState[i]);
       
       lastInputDebounce[i] = millis();
+      }
+    }
+}
+#endif
+#ifdef DALLAS_TEMP_SENSOR
+void readTmpInputs(){
+    for(int i= 0;i<TmpSensors; i++){
+      DallasTemperature * sensor = TmpSensorControlMap[i];
+      sensor->requestTemperatures(); 
+      int v = sensor->getTempCByIndex(0); // Future Todo: Add in support for multiple sensors per pin.
+      // The sensor is returning a double. Future Todo: Enable an option that ouputs the double value if desired
+      int v_f = (v * 9/5) + 32; // Perform conversion to Farenheit if output in F is toggled on below
+      
+      if(inTmpSensorState[i]!= v){
+        inTmpSensorState[i] = v;
+        
+        #if TEMP_OUTPUT_C == 1
+          sendData('T',TmpSensorMap[i],inTmpSensorState[i]);
+        #else
+          sendData('T',TmpSensorMap[i],v_f);
+        #endif
       }
     }
 }
@@ -1049,7 +1117,7 @@ void readCommands(){
                 }
                 else{
                     #ifdef DEBUG
-                    Serial.print("Ungültiges zeichen: ");
+                    Serial.print("Invalid character: ");
                     Serial.println(current);
                     #endif
                 }
@@ -1066,7 +1134,7 @@ void readCommands(){
                 }
                 else{
                   #ifdef DEBUG
-                  Serial.print("Ungültiges zeichen: ");
+                  Serial.print("Invalid character: ");
                   Serial.println(current);
                   #endif
                 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ Just return ```E0:0``` to it. You can now communicate with the Arduino. Further 
 # Installation
 1. configure the .ino file to your demands and flash it to your arduino
 2. connect the arduino to your LinuxCNC Computer via USB
-3. install python-serial  
+3. install python-serial via apt-get
     ```sudo apt-get install python-serial```  
+    or via pip
+    ```sudo pip3 install pyserial```
 4. edit arduino.py to match your arduino settings. If you're running 2.8 change  
   #!/usr/bin/python3.9 in the first line of arduino.py to #!/usr/bin/python2.7.
 5. also check if the Serial adress is correct for your Arduino. I found it easyest to run  

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Just return ```E0:0``` to it. You can now communicate with the Arduino. Further 
   ```sudo   dmesg | grep tty``` in Terminal while plugging and unplugging the arduino a couple of times and whatch which entry is changing. 
 6. make arduino.py executable with chmod +x, delete the suffix .py and copy
 it to /usr/bin  
-    ```sudo chmod +x arduino.py  ```  
+    ```sudo chmod +x arduino-connector.py  ```  
     ```sudo cp arduino-connector.py /usr/bin/arduino-connector  ```  
 
 7. add this entry to the end of your hal file: ```loadusr arduino-connector```  


### PR DESCRIPTION
Added in support for Dallas-compatible temperature sensors.  Chose 'T' to be the output character.  The ability to output in C or F is set by a #define option.  See comments in .ino file for more information.  I will submit further pull requests for the python changes at a later point.  Feel free to change anything you like for the main branch.  Perhaps you want all output to be prefixed with 'O'.  I leave that choice to you. Thank you for your hard work.  I plan on making heavy use of this project for my linuxcnc.  Also changed some output from German to English for consistency.  